### PR TITLE
reject too small terms

### DIFF
--- a/src/DataType.hs
+++ b/src/DataType.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# language DeriveGeneric #-}
@@ -28,6 +29,16 @@ instance Show Term where
       transTerm :: Term -> String
       transTerm (Term x []) = x
       transTerm (Term s xs) = s ++ "(" ++ intercalate "," (map transTerm xs) ++ ")"
+
+foldrTerm :: (String -> b -> b) -> b -> Term -> b
+foldrTerm f x Term { symbol, arguments } =
+  f symbol $ foldr (flip $ foldrTerm f) x arguments
+
+{-|
+The total amount of occurrences of symbols within the given 'Term'.
+-}
+termSize :: Term -> Int
+termSize = foldrTerm (const (+ 1)) 0
 
 instance Show Signature where
   show = show . definitions

--- a/src/Records.hs
+++ b/src/Records.hs
@@ -87,7 +87,7 @@ data SigInstance = SigInstance {
 dSigInst :: SigInstance
 dSigInst = SigInstance {
               symbols = [Symbol "f" [Type "a", Type "b"] (Type "c"), Symbol "g" [] (Type "a"), Symbol "h" [Type "a"] (Type "b")]
-            , terms = [Term "f" [Term "g" [], Term "h" [Term "g" []]], Term "g" [Term "h" []], Term "h" []]
+            , terms = [Term "f" [Term "g" [], Term "h" [Term "g" []]], Term "g" [Term "h" []], Term "f" [Term "h" []]]
             , correct = [1]
             , moreFeedback = False
             , showSolution = False

--- a/src/TermTasks/Direct.hs
+++ b/src/TermTasks/Direct.hs
@@ -10,7 +10,7 @@ import Control.Applicative (Alternative)
 import Control.Monad (when)
 import Control.Monad.Output (
   LangM,
-  OutputMonad (indent, itemizeM, latex, refuse),
+  OutputMonad (indent, itemizeM, latex, refuse, text),
   Rated,
   continueOrAbort,
   english,
@@ -26,7 +26,7 @@ import Test.QuickCheck (Gen, shuffle)
 
 import TermTasks.Helpers
 import TermTasks.Messages
-import DataType (Signature(..), Symbol(..), Type(..))
+import DataType (Signature(..), Symbol(..), Type(..), termSize)
 import Records (Base(..), Certain(..), SigInstance(..))
 import qualified Tasks.CertainSignature as CertainSignature
 
@@ -61,8 +61,11 @@ verifyInst SigInstance{..}
         refuse $ indent $ translate $ do
           english "At least one of the solution indices does not exist."
           german "Mindestens eine der Lösungsindices existiert nicht."
-
-
+    | not $ null nonTrivialTerms = refuse $ do
+        translate $ do
+          english "The following terms are not of at least two symbols:"
+          german "Die folgenden Terme bestehen nicht wenigstens aus zwei Symbolen:"
+        itemizeM $ map (text . show) nonTrivialTerms
     | emptyInput =
         refuse $ indent $ translate $ do
           english "At least one of the given lists is empty."
@@ -78,6 +81,7 @@ verifyInst SigInstance{..}
     notInRange = any (`notElem` [1 .. length terms + 1]) correct
     emptyInput = null symbols || null terms
     doubleSolution = nub correct /= correct
+    nonTrivialTerms = filter ((< 2) . termSize) terms
 
 
 
@@ -112,7 +116,9 @@ verifyBase Base{..}
         refuse $ indent $ translate $ do
           english "At least one quantity is given as a negative number."
           german "Mindestens eine Anzahl wurde als negative Zahl angegeben."
-
+    | fst termSizeRange < 2 = refuse $ translate $ do
+        english "The minimum of 'termSizeRange' has to be at least two."
+        german "Das Mimimum der 'termSizeRange' muss mindestens zwei betragen."
 
     | invalidInterval =
         refuse $ indent $ translate $ do


### PR DESCRIPTION
There is some valid point about this answer:
![image](https://user-images.githubusercontent.com/531939/199999526-1df87f57-41c3-43f8-af5a-c230f63fb08c.png)
as `h` is well-typed (even if it is not first-order).

This pull request prevents tasks of providing such non-first-order options.