### PR TITLE
Changes for Flex-Config of Direct task 

### DIFF
--- a/src/DataType.hs
+++ b/src/DataType.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# language DeriveDataTypeable #-}
 {-# language DeriveGeneric #-}
 {-# language DeriveFunctor #-}
 {-# language DeriveFoldable #-}
@@ -12,20 +13,21 @@ module DataType where
 import GHC.Generics
 import GHC.OverloadedLabels
 import GHC.Records
+import Data.Data (Data)
 import Data.List (nub,intercalate)
 import Test.QuickCheck (Arbitrary(..), elements)
 
 
-newtype Type = Type {name :: String}   deriving (Eq,Generic)
+newtype Type = Type {name :: String}   deriving (Eq,Data,Generic)
 
 data Term a = Term {symbol :: a, arguments :: [Term a]}
-  deriving (Eq, Generic, Functor, Foldable)
+  deriving (Eq, Data, Generic, Functor, Foldable)
 
 newtype Signature = Signature { definitions :: [Symbol]}  deriving (Generic)
-data Symbol = Symbol {symbol :: String, arguments :: [Type], result :: Type} deriving Generic
+data Symbol = Symbol {symbol :: String, arguments :: [Type], result :: Type} deriving (Data, Generic)
 
 data Error = Swap | TypeChange | OneMore | OneLess | NameTypo | UnknownSymbol
-  deriving (Eq, Ord, Show, Read, Bounded, Enum, Generic)
+  deriving (Eq, Ord, Show, Read, Bounded, Enum, Data, Generic)
 
 instance Arbitrary Error where
   arbitrary = elements [minBound .. maxBound]

--- a/src/TermTasks/DataType.hs
+++ b/src/TermTasks/DataType.hs
@@ -1,8 +1,8 @@
 module TermTasks.DataType
        (
          Error(..)
-       , Signature
-       , Symbol
+       , Signature(..)
+       , Symbol(..)
        , Term(..)
        , Type(..)
        , toSignature

--- a/src/TermTasks/Direct.hs
+++ b/src/TermTasks/Direct.hs
@@ -205,7 +205,7 @@ completeGrade SigInstance {..} sol = do
             translate $ do
               english "These incorrect terms are part of your solution: "
               german "Diese Terme aus Ihrer Lösung sind falsch: "
-            itemizeM $ map (latex . show) badTerms
+            itemizeM $ map (latex . inMathit) badTerms
             pure ()
     pure ()
   let what = translations $ do

--- a/src/TermTasks/Helpers.hs
+++ b/src/TermTasks/Helpers.hs
@@ -16,4 +16,4 @@ mathifySignature s = open
     withMathit snip = close ++ snip ++ open
 
 itemifyTerm :: (Int, Term String) -> String
-itemifyTerm (i,t) = show i ++ ".\\," ++ show t
+itemifyTerm (i,t) = show i ++ ".\\," ++ "\\mathit{" ++ show t ++ "}"

--- a/src/TermTasks/Helpers.hs
+++ b/src/TermTasks/Helpers.hs
@@ -1,4 +1,8 @@
-module TermTasks.Helpers where
+module TermTasks.Helpers (
+  mathifySignature,
+  itemifyTerm,
+  inMathit,
+  ) where
 
 import Data.List.Extra (replace)
 import DataType (Term)
@@ -6,14 +10,21 @@ import DataType (Term)
 
 mathifySignature :: String -> String
 mathifySignature s = open
-  ++ replace " : " (withMathit " : ")
-      (replace " -> " (withMathit " \\to ") $
-        replace " x " (withMathit " \\times ") s)
+  ++ replace " : " (around " : ")
+      (replace " -> " (around " \\to ") $
+        replace " x " (around " \\times ") s)
   ++ close
   where
-    open = "\\mathit{"
-    close = "}"
-    withMathit snip = close ++ snip ++ open
+    around snip = close ++ snip ++ open
 
 itemifyTerm :: (Int, Term String) -> String
-itemifyTerm (i,t) = show i ++ ".\\," ++ "\\mathit{" ++ show t ++ "}"
+itemifyTerm (i,t) = show i ++ ".\\," ++ inMathit t
+
+inMathit :: Show a => a -> String
+inMathit a = open ++ show a ++ close
+
+open :: String
+open = "\\mathit{"
+
+close :: String
+close = "}"

--- a/src/TermTasks/Helpers.hs
+++ b/src/TermTasks/Helpers.hs
@@ -5,7 +5,15 @@ import DataType (Term)
 
 
 mathifySignature :: String -> String
-mathifySignature s = replace "->" "\\to" (replace "x" "\\times" s)
+mathifySignature s = open
+  ++ replace " : " (withMathit " : ")
+      (replace " -> " (withMathit " \\to ") $
+        replace " x " (withMathit " \\times ") s)
+  ++ close
+  where
+    open = "\\mathit{"
+    close = "}"
+    withMathit snip = close ++ snip ++ open
 
 itemifyTerm :: (Int, Term String) -> String
 itemifyTerm (i,t) = show i ++ ".\\," ++ show t


### PR DESCRIPTION
- Derive `Data` for some types to use generic show
- Expose constructors of `Symbol` and `Signature` (https://github.com/fmidue/flex-tasks/issues/37)
- use `\mathit` in latex snippets for correct letter spacing