### PR TITLE
Remove 'deriving Typeable' instead of using CPP

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -10,6 +10,3 @@
 
 # ignore long runs of a single character:
 \b([A-Za-z])\g{-1}{3,}\b
-
-# ignore specific CPP directive
-^#endif$

--- a/src/Records.hs
+++ b/src/Records.hs
@@ -1,17 +1,10 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
-#if !MIN_VERSION_base(4,18,0)
-{-# LANGUAGE DerivingStrategies #-}
-#endif
 
 module Records where
 
 import Data.Data (Data)
 import Data.Map (Map)
-#if !MIN_VERSION_base(4,18,0)
-import Data.Typeable (Typeable)
-#endif
 import GHC.Generics
 import Control.OutputCapable.Blocks (Language(..))
 
@@ -27,9 +20,6 @@ data Base = Base
             , extraText :: Maybe (Map Language String)
             }
   deriving Generic
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dBase :: Base
 dBase = Base
@@ -50,9 +40,6 @@ data Certain = Certain {
                , baseConf :: Base
                }
   deriving Generic
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dCertain :: Certain
 dCertain = Certain
@@ -78,9 +65,6 @@ data Perturbed = Perturbed {
                , baseConf :: Base
                }
   deriving Generic
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dPerturbed :: Perturbed
 dPerturbed = Perturbed
@@ -119,9 +103,6 @@ data SigInstance = SigInstance {
                     , addText :: Maybe (Map Language String)
                     }
   deriving (Data, Generic)
-#if !MIN_VERSION_base(4,18,0)
-  deriving Typeable
-#endif
 
 dSigInst :: SigInstance
 dSigInst = SigInstance {


### PR DESCRIPTION
`Typeable` is automatically derived since GHC 7.10 (10 years ago). We decided to drop the CPP directives and instead delete the deriving statements.